### PR TITLE
Modify default location to install RapidCFD on bashrc

### DIFF
--- a/etc/bashrc
+++ b/etc/bashrc
@@ -42,10 +42,10 @@ export WM_PROJECT_VERSION=dev
 #
 # Location of the OpenFOAM installation
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-foamInstall=$HOME/OpenFOAM
-# foamInstall=~/OpenFOAM
-# foamInstall=/opt/OpenFOAM
-# foamInstall=/usr/local/OpenFOAM
+foamInstall=$HOME/$WM_PROJECT
+# foamInstall=~/$WM_PROJECT
+# foamInstall=/opt/$WM_PROJECT
+# foamInstall=/usr/local/$WM_PROJECT
 #
 # END OF (NORMAL) USER EDITABLE PART
 ################################################################################


### PR DESCRIPTION
This modification enable bash user to install Rapid CFD to the computer which OpenFOAM-dev has been installed to.
RapidCFD-dev needs "ThirdParty-dev" which is not same as [OpenFOAM's ThirdParty-dev](https://github.com/OpenFOAM/ThirdParty-dev).

cshrc doesn't need to modified.

(but I wonder why RapidCFD's bashrc is fixed but OpenFOAM-2.3.1's  not...)