### PR TITLE
port turbulentTemperatureCoupledBaffleMixed boundary condition

### DIFF
--- a/src/OpenFOAM/meshes/polyMesh/mapPolyMesh/mapDistribute/mapDistribute.H
+++ b/src/OpenFOAM/meshes/polyMesh/mapPolyMesh/mapDistribute/mapDistribute.H
@@ -609,7 +609,7 @@ public:
             template<class T>
             void distribute
             (
-                List<T>& fld,
+                gpuList<T>& fld,
                 const bool dummyTransform = true,
                 const int tag = UPstream::msgType()
             ) const;

--- a/src/OpenFOAM/meshes/polyMesh/mapPolyMesh/mapDistribute/mapDistributeTemplates.C
+++ b/src/OpenFOAM/meshes/polyMesh/mapPolyMesh/mapDistribute/mapDistributeTemplates.C
@@ -40,7 +40,7 @@ void Foam::mapDistribute::distribute
     const label constructSize,
     const labelListList& subMap,
     const labelListList& constructMap,
-    List<T>& field,
+    gpuList<T>& field,
     const int tag
 )
 {
@@ -910,7 +910,7 @@ void Foam::mapDistribute::distribute
 template<class T>
 void Foam::mapDistribute::distribute
 (
-    List<T>& fld,
+    gpuList<T>& fld,
     const bool dummyTransform,
     const int tag
 ) const

--- a/src/meshTools/mappedPatches/mappedPolyPatch/mappedPatchBase.H
+++ b/src/meshTools/mappedPatches/mappedPolyPatch/mappedPatchBase.H
@@ -420,7 +420,7 @@ public:
 
             //- Wrapper around map/interpolate data distribution
             template<class Type>
-            void distribute(List<Type>& lst) const;
+            void distribute(gpuList<Type>& lst) const;
 
             //- Wrapper around map/interpolate data distribution with operation
             template<class Type, class CombineOp>

--- a/src/meshTools/mappedPatches/mappedPolyPatch/mappedPatchBaseTemplates.C
+++ b/src/meshTools/mappedPatches/mappedPolyPatch/mappedPatchBaseTemplates.C
@@ -24,13 +24,13 @@ License
 \*---------------------------------------------------------------------------*/
 
 template<class Type>
-void Foam::mappedPatchBase::distribute(List<Type>& lst) const
+void Foam::mappedPatchBase::distribute(gpuList<Type>& lst) const
 {
     switch (mode_)
     {
         case NEARESTPATCHFACEAMI:
         {
-            lst = AMI().interpolateToSource(Field<Type>(lst.xfer()));
+            lst = AMI().interpolateToSource(gpuField<Type>(lst.xfer()));
             break;
         }
         default:
@@ -75,7 +75,6 @@ void Foam::mappedPatchBase::distribute
         }
     }
 }
-
 
 template<class Type>
 void Foam::mappedPatchBase::reverseDistribute(List<Type>& lst) const

--- a/src/turbulenceModels/compressible/turbulenceModel/Make/files
+++ b/src/turbulenceModels/compressible/turbulenceModel/Make/files
@@ -3,8 +3,9 @@ laminar/laminar.C
 
 derivedFvPatchFields/turbulentHeatFluxTemperature/turbulentHeatFluxTemperatureFvPatchScalarField.C
 derivedFvPatchFields/temperatureCoupledBase/temperatureCoupledBase.C
-/*
+
 derivedFvPatchFields/turbulentTemperatureCoupledBaffleMixed/turbulentTemperatureCoupledBaffleMixedFvPatchScalarField.C
+/*
 derivedFvPatchFields/thermalBaffle1D/thermalBaffle1DFvPatchScalarFields.C
 */
 derivedFvPatchFields/totalFlowRateAdvectiveDiffusive/totalFlowRateAdvectiveDiffusiveFvPatchScalarField.C

--- a/src/turbulenceModels/compressible/turbulenceModel/derivedFvPatchFields/turbulentTemperatureCoupledBaffleMixed/turbulentTemperatureCoupledBaffleMixedFvPatchScalarField.C
+++ b/src/turbulenceModels/compressible/turbulenceModel/derivedFvPatchFields/turbulentTemperatureCoupledBaffleMixed/turbulentTemperatureCoupledBaffleMixedFvPatchScalarField.C
@@ -241,8 +241,39 @@ void turbulentTemperatureCoupledBaffleMixedFvPatchScalarField::updateCoeffs()
         nbrKDelta() = contactRes_;
     }
 
-    mpp.distribute(nbrIntFld());
-    mpp.distribute(nbrKDelta());
+    tmp<scalarField> nbrIntFld_cpu;
+    tmp<scalarField> nbrKDelta_cpu;
+
+    thrust::copy
+    (
+        nbrIntFld.begin(),
+        nbrIntFld.end(),
+        nbrIntFld_cpu.begin()
+    );
+
+    thrust::copy
+    (
+        nbrKDelta.begin(),
+        nbrKDelta.end(),
+        nbrKDelta_cpu.begin()
+    );
+
+    mpp.distribute(nbrIntFld_cpu());
+    mpp.distribute(nbrKDelta_cpu());
+
+    thrust::copy
+    (
+        nbrIntFld_cpu.begin(),
+        nbrIntFld_cpu.end(),
+        nbrIntFld.begin()
+    );
+
+    thrust::copy
+    (
+        nbrKDelta_cpu.begin(),
+        nbrKDelta_cpu.end(),
+        nbrKDelta.begin()
+    );
 
     tmp<scalargpuField> myKDelta = kappa(*this)*patch().deltaCoeffs();
 


### PR DESCRIPTION
Hi, daniel
I tried to port the turbulentTemperatureCoupledBaffleMixed boundary condition, but I got a problem.
In file mapDistributeTemplates.C line 56 https://github.com/Atizar/RapidCFD-dev/blob/b4b9c7d48ac75d87ad3d93299c3131634fd48a29/src/OpenFOAM/meshes/polyMesh/mapPolyMesh/mapDistribute/mapDistributeTemplates.C
 subField[i] = field[mySubMap[i]]; 
it seems that subField is a cpu Field, does it need to port it to a gpu field? 