### PR TITLE
Remove #if __CUDA_ARCH__ >= 350

### DIFF
--- a/src/OpenFOAM/containers/Lists/gpuList/textures.H
+++ b/src/OpenFOAM/containers/Lists/gpuList/textures.H
@@ -84,15 +84,15 @@ inline void textures<double>::initResourceDesc(cudaResourceDesc& resDesc)
     resDesc.res.linear.desc.y = 32; 
 }
 
-#if __CUDA_ARCH__ >= 350
+//#if __CUDA_ARCH__ >= 350
 
-template<class T>
-inline __device__ T textures<T>::operator[](const int& i) const
-{
-    return __ldg(data + i);
-}
+//template<class T>
+//inline __device__ T textures<T>::operator[](const int& i) const
+//{
+//    return __ldg(data + i);
+//}
 
-#else
+//#else
 
 template<>
 inline __device__ float textures<float>::operator[](const int& i) const
@@ -113,6 +113,6 @@ inline __device__ double textures<double>::operator[](const int& i) const
     return __hiloint2double(v.y, v.x);
 }
 
-#endif
+//#endif
 
 }

--- a/src/OpenFOAM/containers/Lists/gpuList/textures.H
+++ b/src/OpenFOAM/containers/Lists/gpuList/textures.H
@@ -68,7 +68,6 @@ inline void textures<float>::initResourceDesc(cudaResourceDesc& resDesc)
     resDesc.res.linear.desc.x = 32; 
 }
 
-
 template<>
 inline void textures<int>::initResourceDesc(cudaResourceDesc& resDesc)
 {
@@ -83,16 +82,6 @@ inline void textures<double>::initResourceDesc(cudaResourceDesc& resDesc)
     resDesc.res.linear.desc.x = 32; 
     resDesc.res.linear.desc.y = 32; 
 }
-
-//#if __CUDA_ARCH__ >= 350
-
-//template<class T>
-//inline __device__ T textures<T>::operator[](const int& i) const
-//{
-//    return __ldg(data + i);
-//}
-
-//#else
 
 template<>
 inline __device__ float textures<float>::operator[](const int& i) const
@@ -112,7 +101,5 @@ inline __device__ double textures<double>::operator[](const int& i) const
     int2 v = tex1Dfetch<int2>(tex, i);
     return __hiloint2double(v.y, v.x);
 }
-
-//#endif
 
 }

--- a/src/turbulenceModels/compressible/RAS/derivedFvPatchFields/wallFunctions/omegaWallFunctions/omegaWallFunction/omegaWallFunctionFvPatchScalarField.C
+++ b/src/turbulenceModels/compressible/RAS/derivedFvPatchFields/wallFunctions/omegaWallFunctions/omegaWallFunction/omegaWallFunctionFvPatchScalarField.C
@@ -63,6 +63,7 @@ struct omegaWallFunctionGraterThanToleranceFunctor : public std::unary_function<
 {
     const scalar tolerance_;
     omegaWallFunctionGraterThanToleranceFunctor(scalar tolerance): tolerance_(tolerance){}
+    __HOST____DEVICE__
     bool operator () (const scalar& s)
     {
         return s > tolerance_;

--- a/src/turbulenceModels/incompressible/RAS/derivedFvPatchFields/wallFunctions/epsilonWallFunctions/epsilonWallFunction/epsilonWallFunctionFvPatchScalarField.C
+++ b/src/turbulenceModels/incompressible/RAS/derivedFvPatchFields/wallFunctions/epsilonWallFunctions/epsilonWallFunction/epsilonWallFunctionFvPatchScalarField.C
@@ -47,6 +47,7 @@ scalar epsilonWallFunctionFvPatchScalarField::tolerance_ = 1e-5;
 struct epsilonWallFunctionGraterThanToleranceFunctor : public std::unary_function<scalar,bool>{
 	const scalar tolerance_;
 	epsilonWallFunctionGraterThanToleranceFunctor(scalar tolerance): tolerance_(tolerance){}
+    __HOST____DEVICE__
 	bool operator () (const scalar& s){
 		return s > tolerance_;
 	}


### PR DESCRIPTION
These edits fix two problems.
1. Now RapidCFD applications execute after compilation with architecture flag -sm_35 and higher.  Without the proposed edit, RapidCFD will compile but an error will be thrown. See discussion at: https://github.com/Atizar/RapidCFD-dev/issues/39 

2. When RapidCFD is compiled with the appropriate -sm setting for the NVidia card, startup time is reduced.  See discussion at same URL, above.

This edit probably undoes the read-only data cache that was intended with commit e641b43 but removing the proposed lines in textures.H substantially improve the usability of RapidCFD for CUDA ARCH > 300.