### PR TITLE
Further updates for CC >= 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,27 @@ Still in development stage, waiting for your contribution!
 * no overhead for GPU-CPU memory copy
 * can run in parallel on multiple GPUs
 
-### Compilation Instructions for Ubuntu 16.04:
+### Compilation Instructions for Ubuntu 16.04 with CUDA 8.0
 * ensure CUDA 7.5 is not installed from Ubuntu repsitories 
 * ensure you are using a nVidia driver compatible with CUDA 8
   e.g., for the nVidia Tesla K20: http://www.nvidia.com/download/driverResults.aspx/118962/en-us
 * download CUDA 8.0 here: https://developer.nvidia.com/cuda-80-ga2-download-archive
 * install CUDA 8.0 per instructions provided at time of download
 * to compile in parallel, export WM_NCOMPPROCS=10 (as appropriate for your computer)
+* edit RapidCFD-dev/wmake/rules/linux64Nvcc/c++ and c to reflect the architecture of your card
+  e.g., edit -arch=sm_30 according to https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
 * software should compile without errors. Result: RapidCFD for Ubuntu 16.04
 * ThirdParty-dev is needed for multiple GPU's.
 
+### Compilation Instructions for Ubuntu 18.04 with CUDA 9.1
+* install CUDA 9 from the Ubuntu repository
+* Edit /usr/include/thrust/system/cuda/detail and comment out line 87:
+
+```
+//  cuda_cub::throw_on_error(status, "device free failed");
+```
+* edit RapidCFD-dev/wmake/rules/linux64Nvcc/c++ and c to reflect the architecture of your card
+  e.g., edit -arch=sm_30 according to https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
+* to compile in parallel, export WM_NCOMPPROCS=10 (as appropriate for your computer)
+* software should compile without errors. Result: RapidCFD for Ubuntu 16.04
+* ThirdParty-dev is needed for multiple GPU's.

--- a/etc/config/settings.csh
+++ b/etc/config/settings.csh
@@ -354,7 +354,7 @@ case SYSTEMOPENMPI:
     breaksw
 
 case OPENMPI:
-    setenv FOAM_MPI openmpi-1.8.4
+    setenv FOAM_MPI openmpi-2.1.1
     # optional configuration tweaks:
     _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config/openmpi.csh`
 

--- a/etc/config/settings.sh
+++ b/etc/config/settings.sh
@@ -374,7 +374,7 @@ SYSTEMOPENMPI)
     ;;
 
 OPENMPI)
-    export FOAM_MPI=openmpi-1.8.4
+    export FOAM_MPI=openmpi-2.1.1
     # optional configuration tweaks:
     _foamSource `$WM_PROJECT_DIR/bin/foamEtcFile config/openmpi.sh`
 

--- a/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditioner.C
+++ b/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditioner.C
@@ -43,7 +43,6 @@ Foam::AINVPreconditioner::AINVPreconditioner
 
 Foam::AINVPreconditioner::~AINVPreconditioner()
 {
-   rDTex.destroy();
 }
 
 template<bool normalMult>
@@ -73,8 +72,6 @@ void Foam::AINVPreconditioner::preconditionImpl
                                   solver_.matrix().upper():
                                   solver_.matrix().lower();
 
-    textures<scalar> rTex(r);
-
     if(fastPath)
     {
         thrust::transform
@@ -84,8 +81,8 @@ void Foam::AINVPreconditioner::preconditionImpl
             w.begin(),
             AINVPreconditionerFunctor<true,3>
             (
-                rTex,
-                rDTex,
+                r.data(),
+                rD.data(),
                 Lower.data(),
                 Upper.data(),
                 l.data(),
@@ -105,8 +102,8 @@ void Foam::AINVPreconditioner::preconditionImpl
             w.begin(),
             AINVPreconditionerFunctor<false,3>
             (
-                rTex,
-                rDTex,
+                r.data(),
+                rD.data(),
                 Lower.data(),
                 Upper.data(),
                 l.data(),
@@ -118,6 +115,5 @@ void Foam::AINVPreconditioner::preconditionImpl
         );
     }
 
-    rTex.destroy();
 }
 

--- a/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditioner.H
+++ b/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditioner.H
@@ -13,7 +13,6 @@
 #define AINVPreconditioner_H
 
 #include "lduMatrix.H"
-#include "textures.H"
 
 namespace Foam
 {
@@ -23,7 +22,7 @@ class AINVPreconditioner
     public lduMatrix::preconditioner
 {
         scalargpuField rD;
-        textures<scalar> rDTex;
+        scalargpuField rDTex;
 
         AINVPreconditioner(const AINVPreconditioner&);
 

--- a/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditionerF.H
+++ b/src/OpenFOAM/matrices/lduMatrix/preconditioners/AINVPreconditioner/AINVPreconditionerF.H
@@ -5,27 +5,27 @@ namespace Foam
     template<bool fast,int nUnroll>
     struct AINVPreconditionerFunctor 
     {
-        const textures<scalar> psi;
-        const textures<scalar> rD;
+        const scalar* psi;
+        const scalar* rD;
         const scalar* lower;
         const scalar* upper;
-        const label* own;
-        const label* nei;
-        const label* ownStart;
-        const label* losortStart;
-        const label* losort;
+        const __restrict__ label* own;
+        const __restrict__ label* nei;
+        const __restrict__ label* ownStart;
+        const __restrict__ label* losortStart;
+        const __restrict__ label* losort;
 
         AINVPreconditionerFunctor
         (
-            const textures<scalar> _psi, 
-            const textures<scalar> _rD, 
+            const scalar* _psi, 
+            const scalar* _rD, 
             const scalar* _lower,
             const scalar* _upper,
-            const label* _own,
-            const label* _nei,
-            const label* _ownStart,
-            const label* _losortStart,
-            const label* _losort
+            const __restrict__ label* _own,
+            const __restrict__ label* _nei,
+            const __restrict__ label* _ownStart,
+            const __restrict__ label* _losortStart,
+            const __restrict__ label* _losort
         ):
             psi(_psi),
             rD(_rD),
@@ -41,6 +41,69 @@ namespace Foam
         __device__
         scalar operator()(const label& id)
         {
+
+        #if __CUDA_ARCH__ >= 350
+
+            scalar out = 0;
+            scalar tmpSum[2*nUnroll] = {};
+            
+            label oStart = __ldg(&ownStart[id]);
+            label oSize = __ldg(&ownStart[id+1]) - oStart;
+            
+            label nStart = __ldg(&losortStart[id]);
+            label nSize = __ldg(&losortStart[id+1]) - nStart;
+
+            for(label i = 0; i<nUnroll; i++)
+            {
+                if(i<oSize)
+                {
+                    label face = oStart + i;
+
+                    tmpSum[i] = __ldg(&upper[face])*__ldg(&rD[nei[face]])*__ldg(&psi[nei[face]]);
+                }
+            }
+
+            for(label i = 0; i<nUnroll; i++)
+            {
+                if(i<nSize)
+                {
+                    label face = nStart + i;
+                    if(!fast)
+                         face = __ldg(&losort[face]);
+
+                    tmpSum[i+nUnroll] = __ldg(&lower[face])*__ldg(&rD[own[face]])*__ldg(&psi[own[face]]);
+                }
+            }
+
+            #pragma unroll
+            for(label i = 0; i<2*nUnroll; i++)
+            {
+                out+= tmpSum[i]; 
+            }
+            
+            #pragma unroll 2
+            for(label i = nUnroll; i<oSize; i++)
+            {
+                label face = oStart + i;
+
+                out += __ldg(&upper[face])*__ldg(&rD[nei[face]])*__ldg(&psi[nei[face]]);
+            }
+            
+            #pragma unroll 2
+            for(label i = nUnroll; i<nSize; i++)
+            {
+                 label face = nStart + i;
+                 if(!fast)
+                      face = __ldg(&losort[face]);
+
+                 out += __ldg(&lower[face])*__ldg(&rD[own[face]])*__ldg(&psi[own[face]]);
+            }
+
+            
+            return __ldg(&rD[id])*(__ldg(&psi[id])-out);
+ 
+        #else
+        
             scalar out = 0;
             scalar tmpSum[2*nUnroll] = {};
             
@@ -98,6 +161,9 @@ namespace Foam
 
             
             return rD[id]*(psi[id]-out);
+            
+        #endif
+ 
         }
     };
 }

--- a/src/OpenFOAM/matrices/lduMatrix/smoothers/Jacobi/JacobiSmoother.C
+++ b/src/OpenFOAM/matrices/lduMatrix/smoothers/Jacobi/JacobiSmoother.C
@@ -66,8 +66,6 @@ void Foam::JacobiSmoother::smooth
     const scalargpuField& Upper = matrix_.upper();
     const scalargpuField& Diag = matrix_.diag();
 
-    textures<scalar> psiTex(psi);
-
     FieldField<gpuField, scalar>& mBouCoeffs =
         const_cast<FieldField<gpuField, scalar>&>
         (
@@ -115,7 +113,7 @@ void Foam::JacobiSmoother::smooth
                 JacobiSmootherFunctor<true,3>
                 (
                     omega_,
-                    psiTex,
+                    psi.data(),
                     Diag.data(),
                     sourceTmp.data(),
                     Lower.data(),
@@ -140,7 +138,7 @@ void Foam::JacobiSmoother::smooth
                 JacobiSmootherFunctor<false,3>
                 (
                     omega_,
-                    psiTex,
+                    psi.data(),
                     Diag.data(),
                     sourceTmp.data(),
                     Lower.data(),
@@ -165,7 +163,5 @@ void Foam::JacobiSmoother::smooth
             mBouCoeffs[patchi].negate();
         }
     }
-
-    psiTex.destroy();
 }
 

--- a/src/OpenFOAM/matrices/lduMatrix/smoothers/Jacobi/JacobiSmootherF.H
+++ b/src/OpenFOAM/matrices/lduMatrix/smoothers/Jacobi/JacobiSmootherF.H
@@ -1,38 +1,36 @@
 #pragma once
 
-#include "textures.H"
-
 namespace Foam
 {
 
     template<bool fast,int nUnroll>
     struct JacobiSmootherFunctor 
     {
-        const textures<scalar> psi;
+        const scalar* psi;
         const scalar* diag;
         const scalar* b;
         const scalar* lower;
         const scalar* upper;
-        const label* own;
-        const label* nei;
-        const label* ownStart;
-        const label* losortStart;
-        const label* losort;
-        const scalar omega;
+        const __restrict__ label* own;
+        const __restrict__ label* nei;
+        const __restrict__ label* ownStart;
+        const __restrict__ label* losortStart;
+        const __restrict__ label* losort;
+        const __restrict__ scalar omega;
 
         JacobiSmootherFunctor
         (
             scalar _omega,
-            const textures<scalar> _psi, 
+            const scalar* _psi,
             const scalar* _diag, 
             const scalar* _b, 
             const scalar* _lower,
             const scalar* _upper,
-            const label* _own,
-            const label* _nei,
-            const label* _ownStart,
-            const label* _losortStart,
-            const label* _losort
+            const __restrict__ label* _own,
+            const __restrict__ label* _nei,
+            const __restrict__ label* _ownStart,
+            const __restrict__ label* _losortStart,
+            const __restrict__ label* _losort
         ):
             psi(_psi),
             diag(_diag),
@@ -50,6 +48,69 @@ namespace Foam
         __device__
         scalar operator()(const label& id)
         {
+
+        #if __CUDA_ARCH__ >= 350
+        
+            scalar out = 0;
+            scalar tmpSum[2*nUnroll] = {};
+            const scalar rD = 1.0/__ldg(&diag[id]);
+
+            scalar extra = (1 - omega)*__ldg(&psi[id]) + omega*rD*__ldg(&b[id]);
+            
+            label oStart = __ldg(&ownStart[id]);
+            label oSize = __ldg(&ownStart[id+1]) - oStart;
+            
+            label nStart = __ldg(&losortStart[id]);
+            label nSize = __ldg(&losortStart[id+1]) - nStart;
+
+            for(label i = 0; i<nUnroll; i++)
+            {
+                if(i<oSize)
+                {
+                    label face = oStart + i;
+                    tmpSum[i] = __ldg(&upper[face])*__ldg(&psi[nei[face]]);
+                }
+            }
+
+            for(label i = 0; i<nUnroll; i++)
+            {
+                if(i<nSize)
+                {
+                     label face = nStart + i;
+                     if( ! fast) 
+                         face = __ldg(&losort[face]);
+
+                     tmpSum[i+nUnroll] = __ldg(&lower[face])*__ldg(&psi[own[face]]); 
+                }
+            }
+
+            #pragma unroll
+            for(label i = 0; i<2*nUnroll; i++)
+            {
+                out+= tmpSum[i]; 
+            }
+            
+            #pragma unroll 2
+            for(label i = nUnroll; i<oSize; i++)
+            {
+                label face = oStart + i;
+                out += __ldg(&upper[face])*__ldg(&psi[nei[face]]);
+            }
+            
+            #pragma unroll 2
+            for(label i = nUnroll; i<nSize; i++)
+            {
+                 label face = nStart + i;
+                 if( ! fast) 
+                     face = __ldg(&losort[face]);
+
+                 out += __ldg(&lower[face])*__ldg(&psi[own[face]]);
+            }
+            
+            return extra - omega*rD*out;
+ 
+        #else
+    
             scalar out = 0;
             scalar tmpSum[2*nUnroll] = {};
             const scalar rD = 1.0/diag[id];
@@ -107,6 +168,9 @@ namespace Foam
             }
             
             return extra - omega*rD*out;
+ 
+        #endif
+ 
         }
     };
 

--- a/src/OpenFOAM/primitives/functions/DataEntry/polynomial/polynomial.C
+++ b/src/OpenFOAM/primitives/functions/DataEntry/polynomial/polynomial.C
@@ -26,7 +26,6 @@ License
 #include "polynomial.H"
 #include "Time.H"
 #include "addToRunTimeSelectionTable.H"
-#include "textures.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -253,14 +252,14 @@ namespace Foam
 struct polynomialFunctor
 {
     const label size_;
-    const textures<scalar> pre_;
-    const textures<scalar> exp_;
+    const scalar* pre_;
+    const scalar* exp_;
 
     polynomialFunctor
     (
         const label size,
-        const textures<scalar> preCoeffs,
-        const textures<scalar> expCoeffs
+        const scalar* preCoeffs,
+        const scalar* expCoeffs
     ):
         size_(size),
         pre_(preCoeffs),
@@ -292,9 +291,6 @@ Foam::tmp<Foam::scalargpuField > Foam::polynomial::value
     tmp<scalargpuField> tfld(new scalargpuField(x.size()));
     scalargpuField& fld = tfld();
 
-    textures<scalar> preCoeffs(preCoeffs_);
-    textures<scalar> expCoeffs(expCoeffs_);
-
     thrust::transform
     (
         x.begin(),
@@ -303,13 +299,10 @@ Foam::tmp<Foam::scalargpuField > Foam::polynomial::value
         polynomialFunctor
         (
             coeffs_.size(),
-            preCoeffs,
-            expCoeffs
+            preCoeffs_.data(),
+            expCoeffs_.data()
         )
     );
-
-    preCoeffs.destroy();
-    expCoeffs.destroy();
 
     return tfld;
 }


### PR DESCRIPTION
- Check CC version at run-time and skipping creation and destruction of texture object for CC >= 3.5
- Change settings for OpenMPI 2.1.1
Note: at TonkomoLLC Github I have placed  ThirdParty-dev that works with RapidCFD. OpenMPI is 2.1.1. You are welcome to use this on your Github for RapidCFD.  Others may find it helpful.
- Updated README for Ubuntu 18.04 and CUDA 9.1


