### PR TITLE
Enabling to run RapidCFD in parallel with other programs with mpi

### DIFF
--- a/src/Pstream/mpi/PstreamGlobals.C
+++ b/src/Pstream/mpi/PstreamGlobals.C
@@ -31,7 +31,7 @@ namespace Foam
 {
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
-
+MPI_Comm PstreamGlobals::MPI_COMM_FOAM;
 // Outstanding non-blocking operations.
 //! \cond fileScope
 DynamicList<MPI_Request> PstreamGlobals::outstandingRequests_;

--- a/src/Pstream/mpi/PstreamGlobals.H
+++ b/src/Pstream/mpi/PstreamGlobals.H
@@ -51,7 +51,7 @@ namespace Foam
 
 namespace PstreamGlobals
 {
-
+extern MPI_Comm MPI_COMM_FOAM;
 extern DynamicList<MPI_Request> outstandingRequests_;
 
 //extern int nRequests_;

--- a/src/Pstream/mpi/UPstream.C
+++ b/src/Pstream/mpi/UPstream.C
@@ -63,10 +63,20 @@ bool Foam::UPstream::init(int& argc, char**& argv)
 {
     MPI_Init(&argc, &argv);
 
+    int myGlobalRank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &myGlobalRank);
+    MPI_Comm_split
+    (
+        MPI_COMM_WORLD,
+        1,
+        myGlobalRank,
+        &PstreamGlobals::MPI_COMM_FOAM
+    );
+
     int numprocs;
-    MPI_Comm_size(MPI_COMM_WORLD, &numprocs);
+    MPI_Comm_size(PstreamGlobals::MPI_COMM_FOAM, &numprocs);
     int myRank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
+    MPI_Comm_rank(PstreamGlobals::MPI_COMM_FOAM, &myRank);
 
     if (debug)
     {
@@ -161,14 +171,14 @@ void Foam::UPstream::exit(int errnum)
     }
     else
     {
-        MPI_Abort(MPI_COMM_WORLD, errnum);
+        MPI_Abort(PstreamGlobals::MPI_COMM_FOAM, errnum);
     }
 }
 
 
 void Foam::UPstream::abort()
 {
-    MPI_Abort(MPI_COMM_WORLD, 1);
+    MPI_Abort(PstreamGlobals::MPI_COMM_FOAM, 1);
 }
 
 
@@ -340,8 +350,8 @@ void Foam::UPstream::allocatePstreamCommunicator
                 << UPstream::worldComm << Foam::exit(FatalError);
         }
 
-        PstreamGlobals::MPICommunicators_[index] = MPI_COMM_WORLD;
-        MPI_Comm_group(MPI_COMM_WORLD, &PstreamGlobals::MPIGroups_[index]);
+        PstreamGlobals::MPICommunicators_[index] = PstreamGlobals::MPI_COMM_FOAM;
+        MPI_Comm_group(PstreamGlobals::MPI_COMM_FOAM, &PstreamGlobals::MPIGroups_[index]);
         MPI_Comm_rank
         (
             PstreamGlobals::MPICommunicators_[index],


### PR DESCRIPTION
Hi!

Please, consider my addition to your code.

I am working on running Elmer and RapidCFD in parallel by adapting Elmer-OpenFOAM Library [https://github.com/jvencels/EOF-Library](url) but I encountered a problem when running RapidCFD in parallel with another program. It counted Elmer also as a parallel RapidCFD process and resulted in error.

This patch is based on OpenFOAM-6 [https://github.com/OpenFOAM/OpenFOAM-6](url)

Best regards,
Didzis Berenis